### PR TITLE
chore: do contracts build dir ignorable by docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,4 +7,5 @@
 docs
 target
 /src/contracts/node_modules
+/src/contracts/build
 build


### PR DESCRIPTION
Add `src/contracts/build` directory to .dockerignore