### PR TITLE
fix: deposit at smart contracts

### DIFF
--- a/src/contracts/contracts/OrderedIntervalList.sol
+++ b/src/contracts/contracts/OrderedIntervalList.sol
@@ -49,7 +49,7 @@ library OrderedIntervalList {
     function get(Data storage self, uint64 id) internal view returns(Interval storage interval) {
         require(id < self.intervals.length, "interval id doesn't exists in interval set");
         interval = self.intervals[id];
-        //require(interval.end != 0, "interval id doesn't exsits in interval set");
+        //require(interval.end != 0, "interval id doesn't exsits in interval set"); // TODO: why its commented?
     }
 
     /**
@@ -226,7 +226,7 @@ library OrderedIntervalList {
                 "prev should refer to the last interval"
             );
             require(
-                allowGapAfterLast || prev != self.lastIndex || prevInterval.end == begin, 
+                allowGapAfterLast || prev != self.lastIndex || prevInterval.end == begin,
                 "should begin from the end of latest interval when adding to the end"
             );
         }

--- a/src/contracts/contracts/PlasmaAssets.sol
+++ b/src/contracts/contracts/PlasmaAssets.sol
@@ -20,7 +20,7 @@ contract PlasmaAssets is Ownable, PlasmaBlocks {
 
     address constant public MAIN_COIN_ASSET_ID = address(0);
     address constant public ERC721_ASSET_ID = address(1);
-    uint256 constant public ASSET_DECIMALS_TRUNCATION = 10e13; //TODO: will be different for tokens
+    uint256 constant public ASSET_DECIMALS_TRUNCATION = 1e13; //TODO: will be different for tokens
     uint32 constant public PLASMA_ASSETS_TOTAL_SIZE = 2 ** 24 - 1;
 
     bytes32 private _expectedTokenAndTokenIdHash;
@@ -87,6 +87,7 @@ contract PlasmaAssets is Ownable, PlasmaBlocks {
     // Deposits
 
     function deposit() public payable {
+        // TODO: it's may overflows if value be grater than 1e78
         uint64 amount = uint64(msg.value / ASSET_DECIMALS_TRUNCATION);
         (uint64 intervalId, uint64 begin, uint64 end) = _assetLists[MAIN_COIN_ASSET_ID].append(amount);
 
@@ -99,11 +100,12 @@ contract PlasmaAssets is Ownable, PlasmaBlocks {
     function depositERC20(IERC20 token, uint256 amountArg) public {
         require(_assetLists[address(token)].isInitialized(), "Operator should add this token first");
 
+        // TODO: it's may overflows if value be grater than 1e78
         uint64 amount = uint64(amountArg / ASSET_DECIMALS_TRUNCATION);
         (uint64 intervalId, uint64 begin, uint64 end) = _assetLists[address(token)].append(amount);
 
         uint256 preBalance = token.balanceOf(address(this));
-        token.safeTransferFrom(msg.sender, address(this), amount);
+        token.safeTransferFrom(msg.sender, address(this), amount * ASSET_DECIMALS_TRUNCATION);
         uint256 deposited = token.balanceOf(address(this)).sub(preBalance);
 
         emit ERC20Deposited(address(token), msg.sender, deposited);
@@ -214,6 +216,7 @@ contract PlasmaAssets is Ownable, PlasmaBlocks {
         return true;
     }
 
+    // TODO: why its commented?
     // function withdrawalChallangeExistance(
     //   ExitState state,
     //   SumMerkleProof txProof,

--- a/src/contracts/contracts/mocks/Erc20Mock.sol
+++ b/src/contracts/contracts/mocks/Erc20Mock.sol
@@ -1,0 +1,13 @@
+pragma solidity ^0.5.2;
+
+import {Ownable} from "openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import {ERC20Mintable} from "openzeppelin-solidity/contracts/token/ERC20/ERC20Mintable.sol";
+
+contract Erc20Mock is ERC20Mintable, Ownable {
+    // TODO: function/constructor with parameters bellow
+    string public name = "Mock token";
+
+    string public symbol = "MCK";
+
+    uint public decimals = 18;
+}

--- a/src/contracts/test/BankexPlasma.js
+++ b/src/contracts/test/BankexPlasma.js
@@ -1,0 +1,107 @@
+const { BN, ether, balance } = require('openzeppelin-test-helpers');
+const BankexPlasma = artifacts.require('BankexPlasma');
+const Token = artifacts.require('Erc20Mock');
+
+contract('PlasmaBlocks', function (accounts) {
+    let owner = accounts[0];
+    let user = accounts[2];
+
+    describe('deposit', function () {
+        let plasma;
+
+        before(async function () {
+            plasma = await BankexPlasma.new({ from: owner });
+        });
+
+        describe('ether', function () {
+            let tx;
+            let testEtherAmount = ether('42');
+            let userBalance;
+            let contractBalance;
+
+            before(async function () {
+                userBalance = await balance.current(user);
+                contractBalance = await balance.current(plasma.address);
+            });
+
+            it('should deposit', async function () {
+                tx = await plasma.deposit({ from: user, value: testEtherAmount, gasPrice: 0 });
+            });
+
+            it('should transfer asset from user', async function () {
+                let currentBalance = await balance.current(user);
+                assert.equal(userBalance.sub(testEtherAmount).toString(), currentBalance.toString());
+            });
+
+            it('should transfer asset to plasma contract', async function () {
+                let currentBalance = await balance.current(plasma.address);
+                assert.equal(contractBalance.add(testEtherAmount).toString(), currentBalance.toString());
+            });
+
+            it('should emit `CoinDeposited` event', function () {
+                assert.equal(tx.logs.length, 2);
+                assert.equal(tx.logs[0].event, 'CoinDeposited');
+                assert.equal(tx.logs[0].args.who, user);
+                assert.equal(tx.logs[0].args.amount.toString(), testEtherAmount.div(new BN(1e13)).toString());
+            });
+
+            it('should emit `AssetDeposited` event', function () {
+                assert.equal(tx.logs[1].event, 'AssetDeposited');
+                assert.equal(tx.logs[1].args.token, '0x0000000000000000000000000000000000000000');
+                assert.equal(tx.logs[1].args.who, user);
+                assert.equal(tx.logs[1].args.intervalId.toString(), '1');
+                assert.equal(tx.logs[1].args.begin.toString(), '0');
+                assert.equal(tx.logs[1].args.end.toString(), '4199999');
+            });
+        });
+
+        describe('erc20', function () {
+            let tx;
+            let token;
+            let testTokenAmount = ether('42');
+            let userBalance;
+            let contractBalance;
+
+            before(async function () {
+                token = await Token.new({ from: owner });
+                await plasma.setAssetOffset(token.address, 24);
+
+                await token.mint(user, testTokenAmount);
+                await token.approve(plasma.address, testTokenAmount, { from: user });
+
+                userBalance = await token.balanceOf(user);
+                contractBalance = await token.balanceOf(plasma.address);
+            });
+
+            it('should deposit', async function () {
+                tx = await plasma.depositERC20(token.address, testTokenAmount, { from: user });
+            });
+
+            it('should transfer tokens from user', async function () {
+                let currentBalance = await token.balanceOf(user);
+                assert.equal(userBalance.sub(testTokenAmount).toString(), currentBalance.toString());
+            });
+
+            it('should transfer tokens to plasma contract', async function () {
+                let currentBalance = await token.balanceOf(plasma.address);
+                assert.equal(contractBalance.add(testTokenAmount).toString(), currentBalance.toString());
+            });
+
+            it('should emit `CoinDeposited` event', function () {
+                assert.equal(tx.logs.length, 2);
+                assert.equal(tx.logs[0].event, 'ERC20Deposited');
+                assert.equal(tx.logs[0].args.who, user);
+                assert.equal(tx.logs[0].args.amount.toString(), testTokenAmount.toString());
+            });
+
+            it('should emit `AssetDeposited` event', function () {
+                assert.equal(tx.logs[1].event, 'AssetDeposited');
+                assert.equal(tx.logs[1].args.token, token.address);
+                assert.equal(tx.logs[1].args.who, user);
+                assert.equal(tx.logs[1].args.intervalId.toString(), '1');
+                assert.equal(tx.logs[1].args.begin.toString(), '0');
+                assert.equal(tx.logs[1].args.end.toString(), '4199999');
+            });
+        });
+    });
+});


### PR DESCRIPTION
verify smart contract part.
Fix two critical bugs: 

1.  `ASSET_DECIMALS_TRUNCATION` could be 1e13. It will truncate one more digit than really need.
2.  correct token transfer amount. Cause method transfered truncated, not really amount.